### PR TITLE
CNAME survives!

### DIFF
--- a/tools/publish-gh-pages.sh
+++ b/tools/publish-gh-pages.sh
@@ -27,7 +27,7 @@ if [ $error_code != 0 ];then
     echo 'Switch branch fail.'
     exit
 else
-    ls | grep -v _site|xargs rm -rf
+    ls | grep -v _site CNAME|xargs rm -rf
     exe_cmd "cp -r _site/* ."
     exe_cmd "rm -rf _site/"
     exe_cmd "touch .nojekyll"


### PR DESCRIPTION
github.io requires a CNAME file in the root dir to specify the user's custom domain, if any. So it's better not to delete this file.
